### PR TITLE
Configurate branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "dev" ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build and Test with Maven
+        run: mvn -B clean verify --file pom.xml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# UniManager_SHID_11
+# 🏛 UniManager (SHID-11 Edition)
+
+**UniManager** is a console-based Educational ERP (Enterprise Resource Planning) system developed by the SHID-11 student team. This project serves as a practical demonstration of **Object-Oriented Programming (OOP)**, **MVC Architecture**, and robust software design principles in Java.
+
+## 🚀 Key Features
+
+* **🎓 Student Management:** Add, delete, sort, and search for students based on various criteria (e.g., group, grades, budget status).
+* **👔 Teacher Management:** Track university staff, calculate the total salary budget, and filter teachers by academic degree.
+* **💾 In-Memory Storage:** Custom implementation of dynamic arrays with automatic capacity expansion (no external SQL databases used in this sprint).
+* **🖥️ Interactive Console UI:** A multi-level, user-friendly command-line interface with built-in input validation.
+
+## 🏗 Architecture (MVC)
+
+The application strictly follows the **Model-View-Controller** design pattern, featuring an advanced layered architecture with abstract generic services to adhere to the DRY (Don't Repeat Yourself) principle.
+
+* `model/` — POJO data classes (`User`, `Student`, `Teacher`).
+* `service/` — Core business logic. Utilizes an abstract base layer (`UserServiceImpl`) to handle array manipulations, which is then extended by specific domain services.
+* `controller/` — Acts as a bridge, parsing user input and delegating tasks to the services.
+* `view/` — The `ConsoleMenu` that handles the I/O loop.
+
+## 🛠 Tech Stack
+
+* **Language:** Java 21
+* **Build Tool:** Maven
+* **Version Control:** Git & GitHub
+* **CI/CD:** GitHub Actions (Automated build and test pipelines)
+
+## 👨‍💻 Development Team (SHID-11)
+
+| Role                           | Responsibility                                             | Team Member         |
+|:-------------------------------|:-----------------------------------------------------------|:--------------------|
+| **Team Lead / Core Architect** | Base Abstractions, CI/CD, Code Review                      | *Demyd Titenko*     |
+| **Student**                    | Agile task selection (Full-Stack implementation & Testing) | *Maria Pisarenko*   |
+| **Student**                    | Agile task selection (Full-Stack implementation & Testing) | *Polina Prikhodko*  |
+| **Student**                    | Agile task selection (Full-Stack implementation & Testing) | *Andriy Babich*     |
+| **Student**                    | Agile task selection (Full-Stack implementation & Testing) | *Oleksiy Stadnikov* |
+
+
+## 📦 Getting Started
+
+### Prerequisites
+* Java Development Kit (JDK) 21 installed.
+* Apache Maven installed.
+
+### Installation & Run
+
+1. Clone the repository:
+   ```bash
+   git clone [https://github.com/Demyd06/UniManager_SHID_11.git](https://github.com/Demyd06/UniManager_SHID_11.git)

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="LocalVariableName"/>
+        <module name="MethodName"/>
+        <module name="TypeName"/>
+        <module name="MemberName"/>
+        <module name="AvoidStarImport"/>
+        <module name="UnusedImports"/>
+        <module name="NeedBraces"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="HiddenField">
+            <property name="ignoreConstructorParameter" value="true"/>
+            <property name="ignoreSetter" value="true"/>
+        </module>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,31 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.3.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>10.14.0</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError> <linkXRef>false</linkXRef>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal> </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
build: integrate Checkstyle with custom ruleset

- Added maven-checkstyle-plugin to pom.xml.
- Created custom checkstyle.xml configuration.
- Configured essential rules: naming conventions, imports, and code formatting.
- Disabled overly strict rules (e.g., mandatory Javadoc, final parameters) to improve team developer experience.